### PR TITLE
Revamp mobile-friendly multi-view layout

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -19,11 +19,16 @@ document.addEventListener('DOMContentLoaded', () => {
     const bookPagesEl = document.getElementById('book-pages');
     const textModelSelect = document.getElementById('text-model');
     const imageModelSelect = document.getElementById('image-model');
+    const storyPromptInput = document.getElementById('story-prompt');
     const statusBanner = document.getElementById('status-banner');
     const statusBannerIcon = statusBanner ? statusBanner.querySelector('.status-banner__icon') : null;
     const statusBannerText = statusBanner ? statusBanner.querySelector('.status-banner__text') : null;
     const statusBannerClose = statusBanner ? statusBanner.querySelector('.status-banner__close') : null;
     const progressSteps = Array.from(document.querySelectorAll('.progress-tracker__step'));
+    const views = Array.from(document.querySelectorAll('.view'));
+    const navButtons = Array.from(document.querySelectorAll('.app-nav__item'));
+    const quickNavButtons = Array.from(document.querySelectorAll('[data-nav-target]'));
+    const ctaCreate = document.getElementById('cta-create');
 
     let currentBookData = null;
     let progressTimers = [];
@@ -39,6 +44,37 @@ document.addEventListener('DOMContentLoaded', () => {
     statusBannerClose?.addEventListener('click', () => {
         statusBanner?.classList.add('hidden');
     });
+
+    function showView(viewName) {
+        if (!viewName) return;
+        views.forEach(view => {
+            view.classList.toggle('is-active', view.dataset.view === viewName);
+        });
+        navButtons.forEach(button => {
+            button.classList.toggle('is-active', button.dataset.nav === viewName);
+        });
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+        if (viewName === 'create') {
+            requestAnimationFrame(() => {
+                if (!storyPromptInput) return;
+                try {
+                    storyPromptInput.focus({ preventScroll: true });
+                } catch (error) {
+                    storyPromptInput.focus();
+                }
+            });
+        }
+    }
+
+    navButtons.forEach(button => {
+        button.addEventListener('click', () => showView(button.dataset.nav));
+    });
+
+    quickNavButtons.forEach(button => {
+        button.addEventListener('click', () => showView(button.dataset.navTarget));
+    });
+
+    ctaCreate?.addEventListener('click', () => showView('create'));
 
     function toggleDownloadButtons(show) {
         const method = show ? 'remove' : 'add';
@@ -331,7 +367,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     generateBtn?.addEventListener('click', async () => {
-        const prompt = document.getElementById('story-prompt').value.trim();
+        const prompt = storyPromptInput?.value.trim() || '';
         const gradeLevel = document.getElementById('grade-level').value;
         const language = document.getElementById('language').value;
         const artStyle = document.getElementById('art-style').value;

--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Children's Book Generator</title>
+    <title>Story Spark | Venice.ai Children's Books</title>
     <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>📚</text></svg>">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -12,225 +12,311 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
 </head>
 <body>
-    <div class="page-wrapper">
-        <header class="hero">
-            <div class="hero__content">
-                <p class="hero__eyebrow">Powered by Venice.ai</p>
-                <h1>Create dazzling children's storybooks in minutes</h1>
-                <p class="hero__subtitle">Shape a prompt, choose an art style, and watch a full 8-page adventure spring to life with custom illustrations.</p>
-                <ul class="hero__highlights">
-                    <li>🎨 35+ curated illustration styles</li>
-                    <li>📖 Grade-aware writing guidance</li>
-                    <li>✨ Instant, shareable PDF downloads</li>
-                </ul>
-            </div>
-            <div class="hero__art" aria-hidden="true">
-                <div class="hero__planet"></div>
-                <div class="hero__rocket"></div>
-                <div class="hero__stars">
-                    <span></span>
-                    <span></span>
-                    <span></span>
-                    <span></span>
+    <div class="app-shell">
+        <header class="app-header">
+            <div class="brand">
+                <span class="brand__logo" aria-hidden="true">✨</span>
+                <div>
+                    <p class="brand__eyebrow">Powered by Venice.ai</p>
+                    <p class="brand__title">Story Spark</p>
                 </div>
             </div>
+            <button id="cta-create" class="brand__action" type="button">Create</button>
         </header>
 
-        <main class="layout">
-            <section class="card card--form">
-                <div class="card__header">
-                    <h2>Plan your story</h2>
-                    <p>Fill in the details below and we'll orchestrate the writing, character design, and artwork for you.</p>
-                </div>
-
-                <div id="status-banner" class="status-banner hidden" role="status" aria-live="polite">
-                    <span class="status-banner__icon" aria-hidden="true">✨</span>
-                    <span class="status-banner__text">Let's make something magical.</span>
-                    <button type="button" class="status-banner__close" aria-label="Dismiss status message">×</button>
-                </div>
-
-                <ul id="progress-tracker" class="progress-tracker">
-                    <li class="progress-tracker__step" data-step="story">
-                        <span class="progress-tracker__icon">1</span>
-                        <div>
-                            <h3>Story spark</h3>
-                            <p>We shape your prompt into an age-appropriate 8-page tale.</p>
-                        </div>
-                    </li>
-                    <li class="progress-tracker__step" data-step="character">
-                        <span class="progress-tracker__icon">2</span>
-                        <div>
-                            <h3>Hero blueprint</h3>
-                            <p>A consistent main character is designed to guide every page.</p>
-                        </div>
-                    </li>
-                    <li class="progress-tracker__step" data-step="art">
-                        <span class="progress-tracker__icon">3</span>
-                        <div>
-                            <h3>Illustration magic</h3>
-                            <p>Each page receives a bespoke illustration in your chosen style.</p>
-                        </div>
-                    </li>
-                    <li class="progress-tracker__step" data-step="finalize">
-                        <span class="progress-tracker__icon">4</span>
-                        <div>
-                            <h3>Book polish</h3>
-                            <p>Cover, pages, and finale art are bundled into a keepsake.</p>
-                        </div>
-                    </li>
-                </ul>
-
-                <form id="story-form" class="form-grid" novalidate>
-                    <div class="form-group form-group--wide">
-                        <label for="story-prompt">What is the story about?</label>
-                        <textarea id="story-prompt" rows="3" placeholder="e.g., a curious chameleon who learns to change colors" required></textarea>
-                        <p class="helper-text">The richer the prompt, the more vivid the journey. Mention emotions, locations, or character traits for extra sparkle.</p>
+        <main class="app-main">
+            <section class="view view--home is-active" data-view="home">
+                <div class="home-hero">
+                    <p class="home-hero__eyebrow">Story Spark</p>
+                    <h1>Create your own story</h1>
+                    <p class="home-hero__subtitle">Craft a unique story with your child's name and preferences, and watch it come to life with beautiful illustrations.</p>
+                    <button class="btn btn--primary home-hero__cta" type="button" data-nav-target="create">
+                        <span class="btn__sparkle" aria-hidden="true"></span>
+                        Build Your Story
+                    </button>
+                    <div class="home-hero__card-grid">
+                        <article class="home-card">
+                            <h2>Story Spark</h2>
+                            <p>Tell us the heart of your tale and who it's for.</p>
+                        </article>
+                        <article class="home-card">
+                            <h2>Hero Blueprint</h2>
+                            <p>Craft the perfect protagonist for your reader.</p>
+                        </article>
+                        <article class="home-card">
+                            <h2>Illustration Magic</h2>
+                            <p>Choose an art style to bring each scene alive.</p>
+                        </article>
+                        <article class="home-card">
+                            <h2>Book Polish</h2>
+                            <p>Download a keepsake PDF with every page illustrated.</p>
+                        </article>
                     </div>
-
-                    <div class="form-group">
-                        <label for="grade-level">What grade level?</label>
-                        <select id="grade-level">
-                            <option value="1">1st Grade</option>
-                            <option value="2">2nd Grade</option>
-                            <option value="3" selected>3rd Grade</option>
-                            <option value="4">4th Grade</option>
-                            <option value="5">5th Grade</option>
-                        </select>
-                    </div>
-
-                    <div class="form-group">
-                        <label for="language">What language?</label>
-                        <select id="language">
-                            <option value="English" selected>English</option>
-                            <option value="Spanish">Spanish</option>
-                            <option value="French">French</option>
-                            <option value="German">German</option>
-                            <option value="Hindi">Hindi</option>
-                            <option value="Gujarati">Gujarati</option>
-                        </select>
-                    </div>
-
-                    <div class="form-group">
-                        <label for="text-model">Text Generation Model</label>
-                        <select id="text-model">
-                            <option value="">Loading Models...</option>
-                        </select>
-                    </div>
-
-                    <div class="form-group">
-                        <label for="image-model">Image Generation Model</label>
-                        <select id="image-model">
-                            <option value="">Loading Models...</option>
-                        </select>
-                    </div>
-
-                    <div class="form-group form-group--wide">
-                        <label for="art-style">Illustration Style</label>
-                        <select id="art-style">
-                            <optgroup label="Classic Styles">
-                                <option value="whimsical and colorful watercolor">Watercolor</option>
-                                <option value="classic cartoon">Classic Cartoon</option>
-                                <option value="Pixar 3D animation style">3D Animation</option>
-                                <option value="storybook pencil sketch">Pencil Sketch</option>
-                            </optgroup>
-
-                            <optgroup label="Japanese Styles">
-                                <option value="Studio Ghibli anime style" selected>Studio Ghibli</option>
-                                <option value="traditional Japanese ukiyo-e woodblock print style">Ukiyo-e (Japanese Woodblock)</option>
-                                <option value="kawaii cute Japanese manga style">Kawaii Manga</option>
-                                <option value="traditional Japanese sumi-e ink painting style">Sumi-e (Japanese Ink)</option>
-                            </optgroup>
-
-                            <optgroup label="Indian Styles">
-                                <option value="traditional Indian Warli tribal art style with simple geometric figures">Warli (Indian Tribal)</option>
-                                <option value="vibrant Indian Madhubani folk art style with intricate patterns">Madhubani (Indian Folk)</option>
-                                <option value="colorful Indian Rajasthani miniature painting style">Rajasthani Miniature</option>
-                                <option value="traditional Indian Kalamkari hand-painted textile style">Kalamkari (Indian Textile)</option>
-                            </optgroup>
-
-                            <optgroup label="Mexican & Latin American">
-                                <option value="vibrant Mexican Day of the Dead style with colorful skulls and marigolds">Día de los Muertos</option>
-                                <option value="traditional Mexican Talavera pottery art style with blue and white patterns">Talavera (Mexican Pottery)</option>
-                                <option value="colorful Mexican folk art Oaxacan style">Oaxacan Folk Art</option>
-                                <option value="vibrant Brazilian cordel literature illustration style">Brazilian Cordel</option>
-                            </optgroup>
-
-                            <optgroup label="Russian & Eastern European">
-                                <option value="Ivan Bilibin Russian fairy tale illustration style with intricate borders">Ivan Bilibin (Russian)</option>
-                                <option value="traditional Russian Palekh lacquer miniature painting style">Palekh (Russian Lacquer)</option>
-                                <option value="colorful Russian Khokhloma folk art style with golden patterns">Khokhloma (Russian Folk)</option>
-                                <option value="traditional Ukrainian Petrykivka decorative painting style">Petrykivka (Ukrainian)</option>
-                            </optgroup>
-
-                            <optgroup label="African Styles">
-                                <option value="traditional African Ndebele geometric art style with bold patterns">Ndebele (South African)</option>
-                                <option value="vibrant West African Kente cloth pattern style">Kente (West African)</option>
-                                <option value="traditional Ethiopian illuminated manuscript style">Ethiopian Manuscript</option>
-                                <option value="colorful Moroccan zellige tile mosaic art style">Moroccan Zellige</option>
-                            </optgroup>
-
-                            <optgroup label="Middle Eastern & Persian">
-                                <option value="traditional Persian miniature painting style with intricate details">Persian Miniature</option>
-                                <option value="Islamic geometric art style with complex patterns">Islamic Geometric</option>
-                                <option value="traditional Turkish Ebru marbled paper art style">Turkish Ebru</option>
-                                <option value="ornate Arabic calligraphy art style">Arabic Calligraphy</option>
-                            </optgroup>
-
-                            <optgroup label="Other World Styles">
-                                <option value="traditional Chinese brush painting style">Chinese Brush Painting</option>
-                                <option value="Aboriginal Australian dot painting style">Aboriginal Dot Painting</option>
-                                <option value="traditional Scandinavian rosemaling decorative art style">Scandinavian Rosemaling</option>
-                                <option value="vibrant Guatemalan textile weaving art style">Guatemalan Textile</option>
-                                <option value="traditional Inuit stone carving art style">Inuit Stone Carving</option>
-                                <option value="colorful Peruvian Andean folk art style">Peruvian Andean Folk</option>
-                            </optgroup>
-                        </select>
-                    </div>
-
-                    <div class="form-actions">
-                        <button type="button" id="generate-btn" class="btn btn--primary">
-                            <span class="btn__sparkle" aria-hidden="true"></span>
-                            Generate full storybook
-                        </button>
-                        <button type="button" id="download-pdf-btn" class="btn btn--secondary hidden">Download book as PDF</button>
-                    </div>
-                </form>
-
-                <div id="loading" class="loading hidden" aria-live="polite">
-                    <div class="loading__spinner"></div>
-                    <p class="loading__text">Weaving words and illustrations together…</p>
                 </div>
             </section>
 
-            <aside class="card card--tips">
-                <h2>Tips for magical adventures</h2>
-                <ul class="tips-list">
-                    <li><strong>Set the scene:</strong> Mention where the story takes place to guide the illustrations.</li>
-                    <li><strong>Add emotion:</strong> Describe how characters feel so the narrative can lean into the mood.</li>
-                    <li><strong>Define the goal:</strong> A clear challenge or dream helps the story find a satisfying ending.</li>
-                </ul>
-                <div class="callout">
-                    <h3>New! Progress tracker</h3>
-                    <p>Follow each stage of the creative pipeline so you always know what's happening behind the scenes.</p>
-                </div>
-            </aside>
+            <section class="view view--create" data-view="create" aria-labelledby="create-heading">
+                <header class="view__header">
+                    <p class="view__eyebrow">Create a book</p>
+                    <h1 id="create-heading">Craft a personalised adventure</h1>
+                    <p class="view__subtitle">Provide a prompt, choose reading preferences, and let Venice.ai weave words and illustrations together.</p>
+                </header>
 
-            <section id="story-book" class="card card--story hidden" aria-live="polite">
-                <div class="story-header">
-                    <div>
-                        <p class="story-meta">Your illustrated adventure</p>
-                        <h2 id="book-title"></h2>
-                    </div>
-                    <button type="button" id="download-pdf-btn-top" class="btn btn--secondary hidden">Download PDF</button>
+                <div class="create-layout">
+                    <section class="card card--form" aria-label="Story settings">
+                        <div id="status-banner" class="status-banner hidden" role="status" aria-live="polite">
+                            <span class="status-banner__icon" aria-hidden="true">✨</span>
+                            <span class="status-banner__text">Let's make something magical.</span>
+                            <button type="button" class="status-banner__close" aria-label="Dismiss status message">×</button>
+                        </div>
+
+                        <form id="story-form" class="form-grid" novalidate>
+                            <div class="form-group form-group--wide">
+                                <label for="story-prompt">Story spark</label>
+                                <textarea id="story-prompt" rows="3" placeholder="e.g., a curious chameleon who learns to change colors" required></textarea>
+                                <p class="helper-text">The richer the prompt, the more vivid the journey. Mention emotions, locations, or character traits for extra sparkle.</p>
+                            </div>
+
+                            <div class="form-group">
+                                <label for="grade-level">Hero blueprint</label>
+                                <select id="grade-level">
+                                    <option value="1">1st Grade</option>
+                                    <option value="2">2nd Grade</option>
+                                    <option value="3" selected>3rd Grade</option>
+                                    <option value="4">4th Grade</option>
+                                    <option value="5">5th Grade</option>
+                                </select>
+                            </div>
+
+                            <div class="form-group">
+                                <label for="language">Language</label>
+                                <select id="language">
+                                    <option value="English" selected>English</option>
+                                    <option value="Spanish">Spanish</option>
+                                    <option value="French">French</option>
+                                    <option value="German">German</option>
+                                    <option value="Hindi">Hindi</option>
+                                    <option value="Gujarati">Gujarati</option>
+                                </select>
+                            </div>
+
+                            <div class="form-group">
+                                <label for="text-model">Text Generation Model</label>
+                                <select id="text-model">
+                                    <option value="">Loading Models...</option>
+                                </select>
+                            </div>
+
+                            <div class="form-group">
+                                <label for="image-model">Image Generation Model</label>
+                                <select id="image-model">
+                                    <option value="">Loading Models...</option>
+                                </select>
+                            </div>
+
+                            <div class="form-group form-group--wide">
+                                <label for="art-style">Illustration style</label>
+                                <select id="art-style">
+                                    <optgroup label="Classic Styles">
+                                        <option value="whimsical and colorful watercolor">Watercolor</option>
+                                        <option value="classic cartoon">Classic Cartoon</option>
+                                        <option value="Pixar 3D animation style">3D Animation</option>
+                                        <option value="storybook pencil sketch">Pencil Sketch</option>
+                                    </optgroup>
+                                    <optgroup label="Japanese Styles">
+                                        <option value="Studio Ghibli anime style" selected>Studio Ghibli</option>
+                                        <option value="traditional Japanese ukiyo-e woodblock print style">Ukiyo-e (Japanese Woodblock)</option>
+                                        <option value="kawaii cute Japanese manga style">Kawaii Manga</option>
+                                        <option value="traditional Japanese sumi-e ink painting style">Sumi-e (Japanese Ink)</option>
+                                    </optgroup>
+                                    <optgroup label="Indian Styles">
+                                        <option value="traditional Indian Warli tribal art style with simple geometric figures">Warli (Indian Tribal)</option>
+                                        <option value="vibrant Indian Madhubani folk art style with intricate patterns">Madhubani (Indian Folk)</option>
+                                        <option value="colorful Indian Rajasthani miniature painting style">Rajasthani Miniature</option>
+                                        <option value="traditional Indian Kalamkari hand-painted textile style">Kalamkari (Indian Textile)</option>
+                                    </optgroup>
+                                    <optgroup label="Mexican & Latin American">
+                                        <option value="vibrant Mexican Day of the Dead style with colorful skulls and marigolds">Día de los Muertos</option>
+                                        <option value="traditional Mexican Talavera pottery art style with blue and white patterns">Talavera (Mexican Pottery)</option>
+                                        <option value="colorful Mexican folk art Oaxacan style">Oaxacan Folk Art</option>
+                                        <option value="vibrant Brazilian cordel literature illustration style">Brazilian Cordel</option>
+                                    </optgroup>
+                                    <optgroup label="Russian & Eastern European">
+                                        <option value="Ivan Bilibin Russian fairy tale illustration style with intricate borders">Ivan Bilibin (Russian)</option>
+                                        <option value="traditional Russian Palekh lacquer miniature painting style">Palekh (Russian Lacquer)</option>
+                                        <option value="colorful Russian Khokhloma folk art style with golden patterns">Khokhloma (Russian Folk)</option>
+                                        <option value="traditional Ukrainian Petrykivka decorative painting style">Petrykivka (Ukrainian)</option>
+                                    </optgroup>
+                                    <optgroup label="African Styles">
+                                        <option value="traditional African Ndebele geometric art style with bold patterns">Ndebele (South African)</option>
+                                        <option value="vibrant West African Kente cloth pattern style">Kente (West African)</option>
+                                        <option value="traditional Ethiopian illuminated manuscript style">Ethiopian Manuscript</option>
+                                        <option value="colorful Moroccan zellige tile mosaic art style">Moroccan Zellige</option>
+                                    </optgroup>
+                                    <optgroup label="Middle Eastern & Persian">
+                                        <option value="traditional Persian miniature painting style with intricate details">Persian Miniature</option>
+                                        <option value="Islamic geometric art style with complex patterns">Islamic Geometric</option>
+                                        <option value="traditional Turkish Ebru marbled paper art style">Turkish Ebru</option>
+                                        <option value="ornate Arabic calligraphy art style">Arabic Calligraphy</option>
+                                    </optgroup>
+                                    <optgroup label="Other World Styles">
+                                        <option value="traditional Chinese brush painting style">Chinese Brush Painting</option>
+                                        <option value="Aboriginal Australian dot painting style">Aboriginal Dot Painting</option>
+                                        <option value="traditional Scandinavian rosemaling decorative art style">Scandinavian Rosemaling</option>
+                                        <option value="vibrant Guatemalan textile weaving art style">Guatemalan Textile</option>
+                                        <option value="traditional Inuit stone carving art style">Inuit Stone Carving</option>
+                                        <option value="colorful Peruvian Andean folk art style">Peruvian Andean Folk</option>
+                                    </optgroup>
+                                </select>
+                            </div>
+
+                            <div class="form-actions">
+                                <button type="button" id="generate-btn" class="btn btn--primary">
+                                    <span class="btn__sparkle" aria-hidden="true"></span>
+                                    Generate full storybook
+                                </button>
+                                <button type="button" id="download-pdf-btn" class="btn btn--secondary hidden">Download book as PDF</button>
+                            </div>
+                        </form>
+
+                        <div id="loading" class="loading hidden" aria-live="polite">
+                            <div class="loading__spinner"></div>
+                            <p class="loading__text">Weaving words and illustrations together…</p>
+                        </div>
+
+                        <ul id="progress-tracker" class="progress-tracker">
+                            <li class="progress-tracker__step" data-step="story">
+                                <span class="progress-tracker__icon">1</span>
+                                <div>
+                                    <h3>Story spark</h3>
+                                    <p>We shape your prompt into an age-appropriate 8-page tale.</p>
+                                </div>
+                            </li>
+                            <li class="progress-tracker__step" data-step="character">
+                                <span class="progress-tracker__icon">2</span>
+                                <div>
+                                    <h3>Hero blueprint</h3>
+                                    <p>A consistent main character guides every page.</p>
+                                </div>
+                            </li>
+                            <li class="progress-tracker__step" data-step="art">
+                                <span class="progress-tracker__icon">3</span>
+                                <div>
+                                    <h3>Illustration magic</h3>
+                                    <p>Each page gets bespoke artwork in your chosen style.</p>
+                                </div>
+                            </li>
+                            <li class="progress-tracker__step" data-step="finalize">
+                                <span class="progress-tracker__icon">4</span>
+                                <div>
+                                    <h3>Book polish</h3>
+                                    <p>Cover, pages, and finale art are bundled into a keepsake.</p>
+                                </div>
+                            </li>
+                        </ul>
+                    </section>
+
+                    <aside class="card card--tips" aria-label="Tips for magical adventures">
+                        <h2>Tips for magical adventures</h2>
+                        <ul class="tips-list">
+                            <li><strong>Set the scene:</strong> Mention where the story takes place to guide the illustrations.</li>
+                            <li><strong>Add emotion:</strong> Describe how characters feel so the narrative can lean into the mood.</li>
+                            <li><strong>Define the goal:</strong> A clear challenge or dream helps the story find a satisfying ending.</li>
+                        </ul>
+                        <div class="callout">
+                            <h3>Powered by Venice.ai</h3>
+                            <p>Real-time access to text and image models keeps your stories fresh and imaginative.</p>
+                        </div>
+                    </aside>
+
+                    <section id="story-book" class="card card--story hidden" aria-live="polite">
+                        <div class="story-header">
+                            <div>
+                                <p class="story-meta">Your illustrated adventure</p>
+                                <h2 id="book-title"></h2>
+                            </div>
+                            <button type="button" id="download-pdf-btn-top" class="btn btn--secondary hidden">Download PDF</button>
+                        </div>
+                        <div id="book-cover" class="book-cover"></div>
+                        <div id="book-pages" class="book-pages"></div>
+                    </section>
                 </div>
-                <div id="book-cover" class="book-cover"></div>
-                <div id="book-pages" class="book-pages"></div>
+            </section>
+
+            <section class="view view--about" data-view="about" aria-labelledby="about-heading">
+                <header class="view__header">
+                    <p class="view__eyebrow">About</p>
+                    <h1 id="about-heading">Welcome to Story Spark</h1>
+                    <p class="view__subtitle">Our magical app is designed to ignite your child's imagination and foster a love for reading through tailored stories.</p>
+                </header>
+
+                <div class="about-grid">
+                    <article class="feature-card">
+                        <div class="feature-card__icon" aria-hidden="true">🧒</div>
+                        <div>
+                            <h2>Personalised Stories</h2>
+                            <p>Make your child the star of every adventure with prompts that capture their world.</p>
+                        </div>
+                    </article>
+                    <article class="feature-card">
+                        <div class="feature-card__icon" aria-hidden="true">🎨</div>
+                        <div>
+                            <h2>Diverse Illustration Styles</h2>
+                            <p>Choose from global art styles, from Studio Ghibli charm to vibrant Madhubani patterns.</p>
+                        </div>
+                    </article>
+                    <article class="feature-card">
+                        <div class="feature-card__icon" aria-hidden="true">📚</div>
+                        <div>
+                            <h2>Age-Appropriate Content</h2>
+                            <p>Venice.ai automatically balances vocabulary and structure for each grade level.</p>
+                        </div>
+                    </article>
+                    <article class="feature-card">
+                        <div class="feature-card__icon" aria-hidden="true">💾</div>
+                        <div>
+                            <h2>Story Library</h2>
+                            <p>Save, revisit, and share your favourite stories across devices with downloadable PDFs.</p>
+                        </div>
+                    </article>
+                </div>
+
+                <div class="faq">
+                    <h2>Frequently asked questions</h2>
+                    <details>
+                        <summary>How does Story Spark work?</summary>
+                        <p>Provide a prompt, select preferences, and our Venice.ai pipeline generates the narrative, characters, and illustrations in minutes.</p>
+                    </details>
+                    <details>
+                        <summary>Is my child's information safe?</summary>
+                        <p>Absolutely. We only use the details you provide to build the story and never store sensitive information.</p>
+                    </details>
+                    <details>
+                        <summary>How can I contact support?</summary>
+                        <p>Send us an email at support@storyspark.app and our team will be happy to help.</p>
+                    </details>
+                    <details>
+                        <summary>Can I customise the art style?</summary>
+                        <p>Yes! Pick from dozens of curated art styles and Venice.ai will apply your choice across every page consistently.</p>
+                    </details>
+                </div>
             </section>
         </main>
 
-        <footer class="venice-credit">
-            <p>Powered by Venice.ai</p>
-        </footer>
+        <nav class="app-nav" aria-label="Primary navigation">
+            <button class="app-nav__item is-active" type="button" data-nav="home">
+                <span class="app-nav__icon" aria-hidden="true">🏠</span>
+                <span class="app-nav__label">Home</span>
+            </button>
+            <button class="app-nav__item" type="button" data-nav="create">
+                <span class="app-nav__icon" aria-hidden="true">📖</span>
+                <span class="app-nav__label">Create</span>
+            </button>
+            <button class="app-nav__item" type="button" data-nav="about">
+                <span class="app-nav__icon" aria-hidden="true">ℹ️</span>
+                <span class="app-nav__label">About</span>
+            </button>
+        </nav>
     </div>
 
     <script src="app.js"></script>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,357 +1,297 @@
 :root {
-    --bg-gradient-start: #fdf0ff;
-    --bg-gradient-end: #e3f2ff;
-    --card-surface: #ffffff;
-    --accent: #7c5dfa;
-    --accent-soft: rgba(124, 93, 250, 0.12);
-    --accent-strong: #5a3ef4;
-    --accent-secondary: #ff8ba7;
-    --text-main: #2d2a44;
-    --text-muted: #645f82;
-    --border-soft: rgba(45, 42, 68, 0.1);
+    --bg-gradient-start: #fdf4ff;
+    --bg-gradient-end: #e6f7ff;
+    --surface: #ffffff;
+    --surface-alt: rgba(255, 255, 255, 0.7);
+    --border: rgba(61, 45, 121, 0.12);
+    --border-strong: rgba(61, 45, 121, 0.18);
+    --text: #2f265f;
+    --text-muted: #6b6590;
+    --accent: #6f5bff;
+    --accent-strong: #4e38f4;
+    --accent-soft: rgba(111, 91, 255, 0.12);
+    --accent-secondary: #ff7fa5;
     --success: #2eb872;
-    --warning: #f5a623;
     --danger: #f05252;
+    --shadow: 0 20px 45px rgba(56, 45, 94, 0.1);
+    font-size: 16px;
 }
 
 * {
     box-sizing: border-box;
 }
 
-html, body {
-    height: 100%;
-}
-
 body {
-    font-family: 'Patrick Hand', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-    background: radial-gradient(circle at top left, var(--bg-gradient-start), #fff 30%, var(--bg-gradient-end));
-    color: var(--text-main);
     margin: 0;
+    font-family: 'Patrick Hand', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    color: var(--text);
+    background: radial-gradient(circle at top left, var(--bg-gradient-start), #fff 30%, var(--bg-gradient-end));
+    min-height: 100vh;
     display: flex;
     justify-content: center;
-    padding: 1.5rem;
+    padding: 1.5rem clamp(1rem, 5vw, 2rem) 4.5rem;
 }
 
-.page-wrapper {
-    width: min(1200px, 100%);
+.app-shell {
+    width: min(960px, 100%);
+    display: flex;
+    flex-direction: column;
+    min-height: calc(100vh - 3rem);
+    backdrop-filter: blur(6px);
+}
+
+.app-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.75rem 1rem 1.25rem;
+}
+
+.brand {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.brand__logo {
+    display: grid;
+    place-items: center;
+    width: 2.5rem;
+    height: 2.5rem;
+    border-radius: 18px;
+    background: var(--surface);
+    box-shadow: 0 12px 24px rgba(111, 91, 255, 0.15);
+    font-size: 1.5rem;
+}
+
+.brand__eyebrow {
+    margin: 0;
+    text-transform: uppercase;
+    letter-spacing: 0.18em;
+    font-size: 0.7rem;
+    color: var(--text-muted);
+}
+
+.brand__title {
+    margin: 0.2rem 0 0;
+    font-size: 1.3rem;
+    font-weight: 600;
+}
+
+.brand__action {
+    padding: 0.5rem 1rem;
+    border-radius: 999px;
+    background: var(--surface);
+    border: 1px solid var(--border-strong);
+    color: var(--accent-strong);
+    font-size: 0.95rem;
+    cursor: pointer;
+    box-shadow: 0 10px 20px rgba(111, 91, 255, 0.1);
+}
+
+.brand__action:hover {
+    background: var(--accent-soft);
+}
+
+.app-main {
+    flex: 1 1 auto;
     display: flex;
     flex-direction: column;
     gap: 2.5rem;
 }
 
-.hero {
-    position: relative;
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-    gap: 2rem;
-    padding: 2.5rem;
-    border-radius: 28px;
-    background: linear-gradient(135deg, rgba(124, 93, 250, 0.15), rgba(255, 162, 182, 0.18));
-    overflow: hidden;
+.view {
+    display: none;
+    animation: fadeIn 0.3s ease;
 }
 
-.hero::after {
-    content: "";
-    position: absolute;
-    inset: 0;
-    pointer-events: none;
-    background: radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.9), transparent 60%),
-                radial-gradient(circle at 80% 30%, rgba(255, 255, 255, 0.7), transparent 55%),
-                radial-gradient(circle at 50% 90%, rgba(255, 255, 255, 0.6), transparent 60%);
-    opacity: 0.7;
+.view.is-active {
+    display: block;
 }
 
-.hero__content {
-    position: relative;
-    z-index: 1;
+.view__header {
+    padding: 0 1rem;
     display: flex;
     flex-direction: column;
+    gap: 0.35rem;
+}
+
+.view__eyebrow {
+    margin: 0;
+    text-transform: uppercase;
+    letter-spacing: 0.18em;
+    color: var(--accent-strong);
+    font-size: 0.75rem;
+}
+
+.view__header h1 {
+    margin: 0;
+    font-size: clamp(1.9rem, 6vw, 2.6rem);
+    line-height: 1.1;
+}
+
+.view__subtitle {
+    margin: 0;
+    color: var(--text-muted);
+    font-size: 1rem;
+    max-width: 52ch;
+}
+
+.home-hero {
+    padding: 1rem;
+    background: var(--surface-alt);
+    border-radius: 28px;
+    border: 1px solid var(--border);
+    box-shadow: var(--shadow);
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.home-hero__eyebrow {
+    margin: 0;
+    text-transform: uppercase;
+    letter-spacing: 0.18em;
+    color: var(--accent-strong);
+    font-size: 0.75rem;
+}
+
+.home-hero h1 {
+    margin: 0;
+    font-size: clamp(2rem, 8vw, 2.8rem);
+}
+
+.home-hero__subtitle {
+    margin: 0;
+    color: var(--text-muted);
+    font-size: 1.05rem;
+}
+
+.home-hero__card-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
     gap: 1rem;
 }
 
-.hero__eyebrow {
-    text-transform: uppercase;
-    letter-spacing: 0.2em;
-    color: var(--accent-strong);
-    margin: 0;
-    font-size: 0.9rem;
+.home-card {
+    background: var(--surface);
+    border-radius: 18px;
+    padding: 1.25rem;
+    border: 1px solid var(--border);
+    box-shadow: 0 12px 25px rgba(56, 45, 94, 0.08);
 }
 
-.hero h1 {
-    margin: 0;
-    font-size: clamp(2.2rem, 4vw, 3.4rem);
-    line-height: 1.1;
-    color: var(--text-main);
-}
-
-.hero__subtitle {
-    margin: 0;
-    color: var(--text-muted);
+.home-card h2 {
+    margin: 0 0 0.35rem;
     font-size: 1.1rem;
 }
 
-.hero__highlights {
+.home-card p {
     margin: 0;
-    padding: 0;
-    list-style: none;
-    display: grid;
-    gap: 0.5rem;
-    font-size: 1.05rem;
-    color: var(--text-main);
+    color: var(--text-muted);
 }
 
-.hero__art {
+.btn {
     position: relative;
-    display: flex;
-    justify-content: center;
+    border: none;
+    border-radius: 999px;
+    font-size: 1rem;
+    padding: 0.85rem 1.5rem;
+    cursor: pointer;
+    font-weight: 600;
+    display: inline-flex;
     align-items: center;
+    justify-content: center;
+    gap: 0.4rem;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-.hero__planet {
-    width: 220px;
-    height: 220px;
-    background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.95), rgba(124, 93, 250, 0.6));
+.btn__sparkle {
+    width: 0.75rem;
+    height: 0.75rem;
     border-radius: 50%;
-    box-shadow: 0 20px 45px rgba(90, 62, 244, 0.25);
-    animation: float 8s ease-in-out infinite;
+    background: rgba(255, 255, 255, 0.7);
+    box-shadow: 0 0 12px rgba(255, 255, 255, 0.8);
 }
 
-.hero__rocket {
-    position: absolute;
-    width: 90px;
-    height: 170px;
-    background: linear-gradient(160deg, #fff, rgba(255, 255, 255, 0.4));
-    border-radius: 60px 60px 20px 20px;
-    transform: rotate(-12deg);
-    top: 15%;
-    right: 18%;
-    box-shadow: 0 15px 40px rgba(255, 138, 167, 0.25);
-    animation: bob 5s ease-in-out infinite;
+.btn--primary {
+    background: linear-gradient(120deg, var(--accent), var(--accent-secondary));
+    color: #fff;
+    box-shadow: 0 18px 30px rgba(111, 91, 255, 0.35);
 }
 
-.hero__rocket::before,
-.hero__rocket::after {
-    content: "";
-    position: absolute;
-    left: 50%;
-    transform: translateX(-50%);
-    background: linear-gradient(180deg, rgba(255, 190, 133, 0.9), rgba(255, 138, 167, 0));
-    border-radius: 20px;
+.btn--primary:hover {
+    transform: translateY(-2px);
 }
 
-.hero__rocket::before {
-    width: 18px;
-    height: 60px;
-    bottom: -50px;
-    filter: blur(4px);
+.btn--secondary {
+    background: var(--surface);
+    border: 1px solid var(--border-strong);
+    color: var(--accent-strong);
 }
 
-.hero__rocket::after {
-    width: 26px;
-    height: 30px;
-    bottom: -35px;
-    opacity: 0.7;
-    filter: blur(6px);
+.btn--secondary:hover {
+    background: var(--accent-soft);
 }
 
-.hero__stars span {
-    position: absolute;
-    width: 12px;
-    height: 12px;
-    background: rgba(255, 255, 255, 0.9);
-    border-radius: 50%;
-    box-shadow: 0 0 12px rgba(255, 255, 255, 0.6);
-    animation: twinkle 6s ease-in-out infinite;
-}
-
-.hero__stars span:nth-child(1) { top: 10%; left: 20%; animation-delay: 0s; }
-.hero__stars span:nth-child(2) { top: 30%; left: 75%; animation-delay: 1.5s; }
-.hero__stars span:nth-child(3) { top: 70%; left: 25%; animation-delay: 3s; }
-.hero__stars span:nth-child(4) { top: 60%; left: 80%; animation-delay: 4.5s; }
-
-.layout {
+.create-layout {
     display: grid;
-    grid-template-columns: 3fr 2fr;
-    gap: 2rem;
+    gap: 1.5rem;
+    padding: 0 1rem 1rem;
 }
 
 .card {
-    background: var(--card-surface);
+    background: var(--surface);
     border-radius: 24px;
-    padding: 2.25rem;
-    box-shadow: 0 18px 40px rgba(45, 42, 68, 0.08);
-    border: 1px solid var(--border-soft);
+    border: 1px solid var(--border);
+    box-shadow: var(--shadow);
+    padding: clamp(1.5rem, 4vw, 2.25rem);
 }
 
 .card--form {
     display: flex;
     flex-direction: column;
-    gap: 1.75rem;
-}
-
-.card__header h2 {
-    margin: 0;
-    font-size: 1.9rem;
-}
-
-.card__header p {
-    margin: 0.35rem 0 0;
-    color: var(--text-muted);
-}
-
-.status-banner {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    padding: 0.9rem 1.1rem;
-    border-radius: 16px;
-    background: var(--accent-soft);
-    color: var(--accent-strong);
-    border: 1px solid rgba(124, 93, 250, 0.2);
-}
-
-.status-banner.hidden {
-    display: none;
-}
-
-.status-banner__icon {
-    font-size: 1.5rem;
-}
-
-.status-banner__text {
-    flex: 1;
-    font-size: 1.05rem;
-}
-
-.status-banner__close {
-    border: none;
-    background: transparent;
-    font-size: 1.25rem;
-    cursor: pointer;
-    color: inherit;
-    line-height: 1;
-}
-
-.status-banner--success {
-    background: rgba(46, 184, 114, 0.18);
-    color: var(--success);
-    border-color: rgba(46, 184, 114, 0.3);
-}
-
-.status-banner--error {
-    background: rgba(240, 82, 82, 0.15);
-    color: var(--danger);
-    border-color: rgba(240, 82, 82, 0.2);
-}
-
-.progress-tracker {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    display: grid;
-    gap: 1.25rem;
-}
-
-.progress-tracker__step {
-    display: grid;
-    grid-template-columns: 48px 1fr;
-    gap: 1rem;
-    align-items: start;
-    position: relative;
-    padding: 0.75rem 1rem;
-    border-radius: 18px;
-    background: rgba(124, 93, 250, 0.05);
-    border: 1px dashed rgba(124, 93, 250, 0.25);
-    transition: transform 0.3s ease, box-shadow 0.3s ease;
-}
-
-.progress-tracker__step.is-active {
-    border-style: solid;
-    background: rgba(124, 93, 250, 0.12);
-    box-shadow: 0 8px 18px rgba(124, 93, 250, 0.12);
-    transform: translateY(-2px);
-}
-
-.progress-tracker__step.is-complete {
-    border-color: rgba(46, 184, 114, 0.4);
-    background: rgba(46, 184, 114, 0.15);
-}
-
-.progress-tracker__step.is-error {
-    border-color: rgba(240, 82, 82, 0.4);
-    background: rgba(240, 82, 82, 0.12);
-}
-
-.progress-tracker__icon {
-    width: 48px;
-    height: 48px;
-    border-radius: 50%;
-    background: #fff;
-    display: grid;
-    place-items: center;
-    font-weight: 700;
-    color: var(--accent-strong);
-    box-shadow: inset 0 0 0 2px rgba(124, 93, 250, 0.2);
-}
-
-.progress-tracker__step h3 {
-    margin: 0;
-    font-size: 1.1rem;
-}
-
-.progress-tracker__step p {
-    margin: 0.35rem 0 0;
-    color: var(--text-muted);
-    font-size: 0.95rem;
+    gap: 1.5rem;
 }
 
 .form-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-    gap: 1.25rem 1.5rem;
+    gap: 1rem;
 }
 
 #story-form.is-disabled {
-    opacity: 0.7;
-}
-
-#story-form.is-disabled .btn {
+    opacity: 0.6;
     pointer-events: none;
 }
 
 .form-group {
     display: flex;
     flex-direction: column;
-    gap: 0.45rem;
+    gap: 0.5rem;
 }
 
-.form-group--wide {
-    grid-column: 1 / -1;
-}
-
-label {
+.form-group label {
+    font-size: 1rem;
     font-weight: 600;
-    color: var(--text-main);
 }
 
 textarea,
 select {
-    width: 100%;
-    padding: 0.85rem 1rem;
-    border-radius: 14px;
-    border: 1px solid rgba(45, 42, 68, 0.15);
-    font-size: 1rem;
     font-family: inherit;
-    background: rgba(255, 255, 255, 0.95);
-    box-shadow: inset 0 2px 6px rgba(45, 42, 68, 0.05);
+    font-size: 1rem;
+    padding: 0.75rem 0.9rem;
+    border-radius: 16px;
+    border: 1px solid var(--border-strong);
+    background: #f9f7ff;
+    color: var(--text);
+    outline: none;
     transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 textarea:focus,
 select:focus {
-    outline: none;
-    border-color: var(--accent-strong);
-    box-shadow: 0 0 0 4px rgba(124, 93, 250, 0.15);
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px rgba(111, 91, 255, 0.2);
 }
 
 textarea {
@@ -360,87 +300,58 @@ textarea {
 
 .helper-text {
     margin: 0;
-    font-size: 0.9rem;
+    font-size: 0.85rem;
     color: var(--text-muted);
 }
 
 .form-actions {
-    grid-column: 1 / -1;
     display: flex;
-    flex-wrap: wrap;
+    flex-direction: column;
     gap: 0.75rem;
+}
+
+.status-banner {
+    display: flex;
     align-items: center;
-}
-
-button {
-    font-family: inherit;
-}
-
-.btn {
-    border: none;
+    gap: 0.75rem;
+    padding: 0.85rem 1rem;
     border-radius: 16px;
-    padding: 0.9rem 1.8rem;
-    font-size: 1.05rem;
-    font-weight: 600;
+    border: 1px solid var(--border-strong);
+    background: rgba(111, 91, 255, 0.08);
+}
+
+.status-banner.hidden {
+    display: none;
+}
+
+.status-banner__text {
+    flex: 1;
+}
+
+.status-banner__close {
+    background: none;
+    border: none;
+    font-size: 1.1rem;
     cursor: pointer;
-    display: inline-flex;
-    align-items: center;
-    gap: 0.6rem;
-    position: relative;
-    overflow: hidden;
-    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    color: var(--text-muted);
 }
 
-.btn:disabled {
-    cursor: not-allowed;
-    opacity: 0.6;
-    transform: none;
-    box-shadow: none;
+.status-banner--success {
+    background: rgba(46, 184, 114, 0.12);
+    border-color: rgba(46, 184, 114, 0.4);
 }
 
-.btn--primary {
-    background: linear-gradient(135deg, var(--accent-strong), var(--accent-secondary));
-    color: #fff;
-    box-shadow: 0 12px 22px rgba(124, 93, 250, 0.2);
-}
-
-.btn--primary:hover {
-    transform: translateY(-1px);
-    box-shadow: 0 14px 30px rgba(124, 93, 250, 0.25);
-}
-
-.btn--secondary {
-    background: rgba(124, 93, 250, 0.12);
-    color: var(--accent-strong);
-    box-shadow: inset 0 0 0 2px rgba(124, 93, 250, 0.25);
-}
-
-.btn--secondary:hover {
-    transform: translateY(-1px);
-    box-shadow: inset 0 0 0 2px rgba(124, 93, 250, 0.35), 0 12px 24px rgba(124, 93, 250, 0.15);
-}
-
-.btn__sparkle {
-    position: absolute;
-    inset: 0;
-    background: radial-gradient(circle at 30% 20%, rgba(255, 255, 255, 0.6), transparent 55%),
-                radial-gradient(circle at 70% 80%, rgba(255, 255, 255, 0.4), transparent 60%);
-    opacity: 0;
-    transition: opacity 0.2s ease;
-}
-
-.btn--primary:hover .btn__sparkle {
-    opacity: 1;
+.status-banner--error {
+    background: rgba(240, 82, 82, 0.12);
+    border-color: rgba(240, 82, 82, 0.35);
 }
 
 .loading {
-    display: grid;
-    justify-items: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
     gap: 0.75rem;
-    padding: 1.5rem;
-    border-radius: 18px;
-    background: rgba(124, 93, 250, 0.07);
-    border: 1px dashed rgba(124, 93, 250, 0.3);
+    text-align: center;
 }
 
 .loading.hidden {
@@ -448,136 +359,239 @@ button {
 }
 
 .loading__spinner {
-    width: 54px;
-    height: 54px;
+    width: 40px;
+    height: 40px;
     border-radius: 50%;
-    border: 5px solid rgba(124, 93, 250, 0.2);
+    border: 4px solid rgba(111, 91, 255, 0.2);
     border-top-color: var(--accent-strong);
     animation: spin 1s linear infinite;
 }
 
-.loading__text {
+.progress-tracker {
+    list-style: none;
     margin: 0;
-    color: var(--text-muted);
-    font-size: 1.05rem;
-    text-align: center;
+    padding: 0;
+    display: grid;
+    gap: 0.75rem;
+}
+
+.progress-tracker__step {
+    display: flex;
+    gap: 0.9rem;
+    padding: 0.75rem 1rem;
+    border-radius: 18px;
+    border: 1px solid var(--border);
+    background: #f7f5ff;
+}
+
+.progress-tracker__icon {
+    width: 32px;
+    height: 32px;
+    border-radius: 10px;
+    background: var(--surface);
+    display: grid;
+    place-items: center;
+    font-weight: 600;
+    color: var(--accent-strong);
+}
+
+.progress-tracker__step.is-active {
+    border-color: var(--accent);
+    background: rgba(111, 91, 255, 0.1);
+}
+
+.progress-tracker__step.is-complete {
+    border-color: rgba(46, 184, 114, 0.5);
+    background: rgba(46, 184, 114, 0.12);
+}
+
+.progress-tracker__step.is-error {
+    border-color: rgba(240, 82, 82, 0.5);
+    background: rgba(240, 82, 82, 0.12);
 }
 
 .card--tips {
     display: flex;
     flex-direction: column;
-    gap: 1.5rem;
-    background: linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(255, 247, 253, 0.9));
+    gap: 1rem;
+}
+
+.card--tips h2 {
+    margin: 0;
 }
 
 .tips-list {
     margin: 0;
-    padding-left: 1.1rem;
+    padding-left: 1.2rem;
     display: flex;
     flex-direction: column;
     gap: 0.75rem;
     color: var(--text-muted);
-    font-size: 1rem;
 }
 
 .callout {
+    background: rgba(255, 127, 165, 0.12);
     border-radius: 18px;
-    padding: 1.25rem;
-    background: rgba(255, 138, 167, 0.12);
-    border: 1px solid rgba(255, 138, 167, 0.3);
-}
-
-.callout h3 {
-    margin-top: 0;
-    margin-bottom: 0.5rem;
-    font-size: 1.25rem;
-}
-
-.callout p {
-    margin: 0;
-    color: var(--text-muted);
+    padding: 1rem;
+    border: 1px solid rgba(255, 127, 165, 0.35);
 }
 
 .card--story {
-    grid-column: 1 / -1;
     display: flex;
     flex-direction: column;
-    gap: 2rem;
+    gap: 1.25rem;
 }
 
 .story-header {
     display: flex;
-    flex-wrap: wrap;
-    justify-content: space-between;
-    align-items: center;
-    gap: 1rem;
+    flex-direction: column;
+    gap: 0.75rem;
 }
 
 .story-meta {
     margin: 0;
     text-transform: uppercase;
     letter-spacing: 0.18em;
-    font-size: 0.85rem;
-    color: var(--accent-strong);
+    font-size: 0.75rem;
+    color: var(--text-muted);
 }
 
-#book-title {
-    margin: 0.4rem 0 0;
-    font-size: clamp(2rem, 4vw, 3rem);
-}
-
-.book-cover img {
+.book-cover img,
+.book-pages img {
     width: 100%;
-    border-radius: 24px;
-    box-shadow: 0 24px 40px rgba(45, 42, 68, 0.18);
+    border-radius: 20px;
+    box-shadow: 0 15px 30px rgba(56, 45, 94, 0.2);
 }
 
 .book-pages {
     display: grid;
-    gap: 1.5rem;
+    gap: 1.25rem;
 }
 
 .page {
     display: grid;
-    gap: 1.5rem;
-    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-    background: rgba(255, 255, 255, 0.8);
-    border-radius: 22px;
-    padding: 1.5rem;
-    border: 1px solid rgba(45, 42, 68, 0.08);
-    box-shadow: 0 12px 24px rgba(45, 42, 68, 0.08);
+    gap: 1rem;
+    padding: 1rem;
+    border-radius: 20px;
+    background: #f9f7ff;
+    border: 1px solid var(--border);
 }
 
 .page-image-container {
-    background: linear-gradient(145deg, rgba(124, 93, 250, 0.12), rgba(255, 138, 167, 0.12));
-    border-radius: 18px;
+    background: #fff;
     padding: 0.75rem;
-    display: grid;
-    place-items: center;
+    border-radius: 16px;
+    display: flex;
+    justify-content: center;
 }
 
 .page-image-container img {
     width: 100%;
-    border-radius: 16px;
-    object-fit: cover;
-    box-shadow: 0 10px 20px rgba(45, 42, 68, 0.18);
-}
-
-.page-content {
-    display: flex;
-    flex-direction: column;
-    gap: 0.75rem;
+    border-radius: 14px;
 }
 
 .page-header h3 {
     margin: 0;
-    font-size: 1.4rem;
 }
 
 .page-text {
     margin: 0;
-    font-size: 1.2rem;
-    line-height: 1.7;
+    color: var(--text-muted);
+    line-height: 1.5;
+}
+
+.app-nav {
+    position: sticky;
+    bottom: 0;
+    margin-top: 2rem;
+    background: var(--surface);
+    border-radius: 24px;
+    border: 1px solid var(--border);
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    box-shadow: 0 20px 40px rgba(56, 45, 94, 0.12);
+    overflow: hidden;
+}
+
+.app-nav__item {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.15rem;
+    padding: 0.65rem 0;
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 0.95rem;
+    color: var(--text-muted);
+}
+
+.app-nav__item.is-active {
+    color: var(--accent-strong);
+    background: rgba(111, 91, 255, 0.1);
+}
+
+.app-nav__icon {
+    font-size: 1.35rem;
+}
+
+.about-grid {
+    display: grid;
+    gap: 1rem;
+    padding: 0 1rem 1rem;
+}
+
+.feature-card {
+    display: flex;
+    gap: 1rem;
+    align-items: flex-start;
+    background: var(--surface);
+    border-radius: 20px;
+    border: 1px solid var(--border);
+    box-shadow: 0 12px 24px rgba(56, 45, 94, 0.08);
+    padding: 1.25rem;
+}
+
+.feature-card__icon {
+    font-size: 1.8rem;
+}
+
+.feature-card h2 {
+    margin: 0 0 0.35rem;
+}
+
+.feature-card p {
+    margin: 0;
+    color: var(--text-muted);
+}
+
+.faq {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    padding: 0 1rem 2rem;
+}
+
+.faq h2 {
+    margin: 0;
+}
+
+.faq details {
+    border-radius: 18px;
+    border: 1px solid var(--border);
+    background: var(--surface);
+    padding: 0.85rem 1rem;
+    box-shadow: 0 12px 24px rgba(56, 45, 94, 0.05);
+}
+
+.faq summary {
+    font-weight: 600;
+    cursor: pointer;
+}
+
+.faq p {
+    margin: 0.5rem 0 0;
     color: var(--text-muted);
 }
 
@@ -585,11 +599,62 @@ button {
     display: none !important;
 }
 
-.venice-credit {
-    text-align: center;
-    margin-bottom: 1rem;
-    color: var(--text-muted);
-    font-size: 0.85rem;
+@media (min-width: 640px) {
+    .form-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .form-group--wide,
+    .form-actions {
+        grid-column: 1 / -1;
+    }
+
+    .story-header {
+        flex-direction: row;
+        align-items: center;
+        justify-content: space-between;
+    }
+}
+
+@media (min-width: 820px) {
+    body {
+        padding-bottom: 3rem;
+    }
+
+    .create-layout {
+        grid-template-columns: 1.1fr 0.9fr;
+    }
+
+    .create-layout > .card--story {
+        grid-column: 1 / -1;
+    }
+
+    .progress-tracker {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .book-pages {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .about-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+}
+
+@media (min-width: 1024px) {
+    .create-layout {
+        grid-template-columns: 1fr 0.6fr;
+        align-items: start;
+    }
+
+    .create-layout > .card--story {
+        grid-column: 1 / -1;
+    }
+
+    .progress-tracker {
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+    }
 }
 
 @keyframes spin {
@@ -598,58 +663,13 @@ button {
     }
 }
 
-@keyframes float {
-    0%, 100% { transform: translateY(-6px); }
-    50% { transform: translateY(8px); }
-}
-
-@keyframes bob {
-    0%, 100% { transform: translateY(-8px) rotate(-12deg); }
-    50% { transform: translateY(6px) rotate(-8deg); }
-}
-
-@keyframes twinkle {
-    0%, 100% { opacity: 0.5; transform: scale(0.9); }
-    50% { opacity: 1; transform: scale(1.1); }
-}
-
-@media (max-width: 1080px) {
-    .layout {
-        grid-template-columns: 1fr;
+@keyframes fadeIn {
+    from {
+        opacity: 0;
+        transform: translateY(8px);
     }
-
-    .card--story {
-        grid-column: 1;
-    }
-}
-
-@media (max-width: 720px) {
-    body {
-        padding: 1rem;
-    }
-
-    .hero {
-        padding: 2rem;
-    }
-
-    .card {
-        padding: 1.75rem;
-    }
-
-    .progress-tracker__step {
-        grid-template-columns: 1fr;
-        text-align: center;
-    }
-
-    .progress-tracker__icon {
-        margin: 0 auto;
-    }
-
-    .form-actions {
-        justify-content: center;
-    }
-
-    .story-header {
-        justify-content: center;
+    to {
+        opacity: 1;
+        transform: translateY(0);
     }
 }


### PR DESCRIPTION
## Summary
- redesign the public landing into Home, Create, and About views with bottom navigation and CTA wiring for Venice.ai powered flows
- refresh the styling to a mobile-first layout with responsive cards, progress tracker, and sticky navigation bar
- add client-side routing helpers so navigation buttons switch views and focus the story prompt on the Create screen

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2999f4f8c8331ba4fda852b4509b2