### PR TITLE
Add offline fallback story generation mode

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -248,7 +248,8 @@ document.addEventListener('DOMContentLoaded', () => {
                 throw new Error(message);
             }
 
-            const { textModels, imageModels } = await response.json();
+            const data = await response.json();
+            const { textModels = [], imageModels = [], fallback = false } = data;
 
             const renderOption = (selectEl, model, fallbackLabel) => {
                 const option = document.createElement('option');
@@ -290,7 +291,11 @@ document.addEventListener('DOMContentLoaded', () => {
                 imageModelSelect.innerHTML = '<option value="">No image models found</option>';
             }
 
-            setStatus('Models ready! Choose your creative combo to begin.', 'success');
+            if (fallback) {
+                setStatus('Offline demo mode: using built-in storyteller and illustrator.', 'info');
+            } else {
+                setStatus('Models ready! Choose your creative combo to begin.', 'success');
+            }
             textModelSelect.disabled = false;
             imageModelSelect.disabled = false;
         } catch (error) {


### PR DESCRIPTION
## Summary
- read Venice.ai credentials from the environment and detect when the API is unavailable
- provide an offline fallback storyteller/illustrator that returns SVG-based imagery and demo story data
- surface fallback mode messaging in the client when mock models are returned

## Testing
- npm start
- curl -s http://localhost:3000/api/models | jq
- curl -s -X POST http://localhost:3000/api/story -H 'Content-Type: application/json' -d '{"prompt":"a shy fox finds courage","gradeLevel":"3","language":"English","artStyle":"Playful cartoon","model":"mock-storyteller","imageModel":"venice-sd35"}' | jq '.title,.story[0],.pageImageUrls[0]'


------
https://chatgpt.com/codex/tasks/task_e_68e3180d8e8c833180e1c6eb1f070e00